### PR TITLE
fix: prevent memory leaks in CoordinatorLayout and ViewPager2

### DIFF
--- a/coordinatorlayout/coordinatorlayout/src/main/java/androidx/coordinatorlayout/widget/CoordinatorLayout.java
+++ b/coordinatorlayout/coordinatorlayout/src/main/java/androidx/coordinatorlayout/widget/CoordinatorLayout.java
@@ -74,6 +74,7 @@ import org.jspecify.annotations.Nullable;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.lang.ref.WeakReference;
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -193,7 +194,8 @@ public class CoordinatorLayout extends ViewGroup implements NestedScrollingParen
     //Sesl
     private boolean mEnableAutoCollapsingKeyEvent = true;
     private boolean mToolIsMouse;
-    private View mLastNestedScrollingChild;
+    //sesl: WeakReference prevents detached fragment views from leaking
+    private WeakReference<View> mLastNestedScrollingChild;
     //sesl
 
     private OnPreDrawListener mOnPreDrawListener;
@@ -291,7 +293,7 @@ public class CoordinatorLayout extends ViewGroup implements NestedScrollingParen
             vto.removeOnPreDrawListener(mOnPreDrawListener);
         }
         if (mNestedScrollingTarget != null) {
-            mLastNestedScrollingChild = mNestedScrollingTarget;
+            mLastNestedScrollingChild = new WeakReference<>(mNestedScrollingTarget); //sesl
             onStopNestedScroll(mNestedScrollingTarget);
         }
         mIsAttachedToWindow = false;
@@ -1844,7 +1846,7 @@ public class CoordinatorLayout extends ViewGroup implements NestedScrollingParen
             int axes, int type) {
         mNestedScrollingParentHelper.onNestedScrollAccepted(child, target, axes, type);
         mNestedScrollingTarget = target;
-        mLastNestedScrollingChild = target;//sesl
+        mLastNestedScrollingChild = new WeakReference<>(target); //sesl
 
         final int childCount = getChildCount();
         for (int i = 0; i < childCount; i++) {
@@ -1872,7 +1874,7 @@ public class CoordinatorLayout extends ViewGroup implements NestedScrollingParen
     public void onStopNestedScroll(@NonNull View target, int type) {
         mNestedScrollingParentHelper.onStopNestedScroll(target, type);
 
-        mLastNestedScrollingChild = target;//sesl
+        mLastNestedScrollingChild = new WeakReference<>(target); //sesl
 
         final int childCount = getChildCount();
         for (int i = 0; i < childCount; i++) {
@@ -3502,11 +3504,13 @@ public class CoordinatorLayout extends ViewGroup implements NestedScrollingParen
                 }
 
                 if (event.getAction() == MotionEvent.ACTION_SCROLL) {
-                    if (mLastNestedScrollingChild != null) {
+                    final View lastScrollChild = mLastNestedScrollingChild != null
+                            ? mLastNestedScrollingChild.get() : null; //sesl
+                    if (lastScrollChild != null) {
                         if (event.getAxisValue(MotionEvent.AXIS_VSCROLL) < 0) {
                             ablBehavior.seslSetExpanded(false);
                         } else if (event.getAxisValue(MotionEvent.AXIS_VSCROLL) > 0
-                                && !mLastNestedScrollingChild.canScrollVertically(-1)) {
+                                && !lastScrollChild.canScrollVertically(-1)) {
                             ablBehavior.seslSetExpanded(true);
                         }
                     } else if (event.getAxisValue(MotionEvent.AXIS_VSCROLL) < 0) {
@@ -3533,7 +3537,7 @@ public class CoordinatorLayout extends ViewGroup implements NestedScrollingParen
      * @param view The child view that initiated the nested scroll.
      */
     public void seslSetNestedScrollingChild(View view) {
-        mLastNestedScrollingChild = view;
+        mLastNestedScrollingChild = view != null ? new WeakReference<>(view) : null; //sesl
     }
 
     /**

--- a/coordinatorlayout/coordinatorlayout/src/main/java/androidx/coordinatorlayout/widget/CoordinatorLayout.java
+++ b/coordinatorlayout/coordinatorlayout/src/main/java/androidx/coordinatorlayout/widget/CoordinatorLayout.java
@@ -293,7 +293,6 @@ public class CoordinatorLayout extends ViewGroup implements NestedScrollingParen
             vto.removeOnPreDrawListener(mOnPreDrawListener);
         }
         if (mNestedScrollingTarget != null) {
-            mLastNestedScrollingChild = new WeakReference<>(mNestedScrollingTarget); //sesl
             onStopNestedScroll(mNestedScrollingTarget);
         }
         mIsAttachedToWindow = false;

--- a/viewpager2/viewpager2/src/main/java/androidx/viewpager2/adapter/FragmentStateAdapter.java
+++ b/viewpager2/viewpager2/src/main/java/androidx/viewpager2/adapter/FragmentStateAdapter.java
@@ -634,6 +634,7 @@ public abstract class FragmentStateAdapter extends
         private ViewPager2.OnPageChangeCallback mPageChangeCallback;
         private RecyclerView.AdapterDataObserver mDataObserver;
         private LifecycleEventObserver mLifecycleObserver;
+        private View.OnAttachStateChangeListener mViewPagerAttachStateListener;
         private ViewPager2 mViewPager;
 
         private long mPrimaryItemId = NO_ID;
@@ -674,11 +675,27 @@ public abstract class FragmentStateAdapter extends
                 }
             };
             mLifecycle.addObserver(mLifecycleObserver);
+
+            // Null mViewPager when detached to break the retain chain:
+            // mLifecycleObserver (on fragment lifecycle) -> FragmentMaxLifecycleEnforcer -> mViewPager -> child views
+            mViewPagerAttachStateListener = new View.OnAttachStateChangeListener() {
+                @Override
+                public void onViewAttachedToWindow(@NonNull View v) {
+                    mViewPager = (ViewPager2) v;
+                }
+
+                @Override
+                public void onViewDetachedFromWindow(@NonNull View v) {
+                    mViewPager = null;
+                }
+            };
+            mViewPager.addOnAttachStateChangeListener(mViewPagerAttachStateListener);
         }
 
         void unregister(@NonNull RecyclerView recyclerView) {
             ViewPager2 viewPager = inferViewPager(recyclerView);
             viewPager.unregisterOnPageChangeCallback(mPageChangeCallback);
+            viewPager.removeOnAttachStateChangeListener(mViewPagerAttachStateListener);
             unregisterAdapterDataObserver(mDataObserver);
             mLifecycle.removeObserver(mLifecycleObserver);
             mViewPager = null;
@@ -687,6 +704,10 @@ public abstract class FragmentStateAdapter extends
         void updateFragmentMaxLifecycle(boolean dataSetChanged) {
             if (shouldDelayFragmentTransactions()) {
                 return; /* recovery step via {@link #mLifecycleObserver} */
+            }
+
+            if (mViewPager == null) {
+                return;
             }
 
             if (mViewPager.getScrollState() != ViewPager2.SCROLL_STATE_IDLE) {


### PR DESCRIPTION
## Summary

### CoordinatorLayout
- `mLastNestedScrollingChild` changed from strong `View` ref to `WeakReference<View>` — prevents detached fragment views from being retained after back-stack navigation
- Removed redundant assignment in `onDetachedFromWindow` (the subsequent `onStopNestedScroll` call already performs the same assignment)
- All write sites wrap the value in `new WeakReference<>(view)` or `null`; the one read site in `dispatchGenericMotionEvent` resolves via `.get()` into a local before use

### ViewPager2 / FragmentStateAdapter
- `FragmentStateAdapter(Fragment)` registers `mLifecycleObserver` on the host **fragment** lifecycle (not view lifecycle). The observer captures `FragmentMaxLifecycleEnforcer` → `mViewPager` → child fragment views, retaining ~7 MB after the host fragment's view is destroyed
- Fix: `FragmentMaxLifecycleEnforcer` now adds an `OnAttachStateChangeListener` to the `ViewPager2` that nulls `mViewPager` on window-detach and restores it on reattach, breaking the retain chain without removing the lifecycle observer
- `updateFragmentMaxLifecycle()` guarded with null check; `unregister()` also removes the attach state listener

## Test plan
- [ ] Navigate between fragments using `CoordinatorLayout` and verify LeakCanary reports no `mLastNestedScrollingChild`-related leaks
- [ ] Navigate between fragments hosting a `ViewPager2` with `FragmentStateAdapter` and verify LeakCanary reports no VP2 / child fragment view leaks
- [ ] Confirm nested scroll / app bar expand-collapse and ViewPager2 paging behaviour are unchanged